### PR TITLE
Add NSIDC and their tutorials repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A prototype of a curated list of awesome data sources, models, tools and organiz
 ### Cryo Software
 ### Cryo Data 
 - [NSIDC](https://nsidc.org/) - The (US) National Snow and Ice Data Center
+- [NSIDC Data Tutorials](https://github.com/nsidc/NSIDC-Data-Tutorials) - Jupyter notebook guides to access, subset, transform, and visualize data products from NSIDC
 ## Frozen Ground/Permafrost
 ### FGP Software
 ### FGP Data

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A prototype of a curated list of awesome data sources, models, tools and organiz
 ## Cryosphere - across all subspheres
 ### Cryo Software
 ### Cryo Data 
+- [NSIDC](https://nsidc.org/) - The (US) National Snow and Ice Data Center
 ## Frozen Ground/Permafrost
 ### FGP Software
 ### FGP Data


### PR DESCRIPTION
First commit adds a link to the (US) National Snow and Ice Data Center.  Second links to the NSIDC Data Tutorials repository.  I think they go together so I'm submitting one PR with the two commits.

Not sure if the tutorials link belongs in the data section, where it can be close to the NSIDC link itself, or elsewhere.  Happy to modify.