### PR TITLE
Add McCarthy International Summer School in Glaciology course material

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,14 +162,16 @@ hydrology and glacier dynamics (paper)
 - [OGGM-edu](http://edu.oggm.org) - Educational material about glaciers, powered by OGGM and MyBinder
 - [glacier-graphics](https://github.com/OGGM/glacier-graphics) - A collection of glacier graphics that can be used for education and outreach
 - [Ed Bueler's Karthaus material](https://github.com/bueler/karthaus) - Notes and codes for Ed Bueler's numerical lectures at Karthaus (Italy) Summer School on Ice Sheets and Glaciers
-- [Ed Bueler's McCarthy material](https://github.com/bueler/mccarthy) - Ed Bueler's slides, notes, and codes on numerical glacier and ice sheet modeling, for the International Summer School in Glaciology, McCarthy, AK
 - [UW_Geodetic_Mass_Budget_Scripts](https://github.com/ShashankBice/UW_Geodetic_Mass_Budget_Scripts) - no description provided
-- [Andy Aschwanden's McCarthy material](https://github.com/aaschwanden/mccarthy-summerschool) - International Summer School in Glaciology, McCarthy, AK. Lecture notes and excercises by Andy Aschwanden
 - [Glaciers Dynamics Lecture](https://github.com/aaschwanden/glaciers617) - Glacier Dynamics lecture by Andy Aschwanden
 - [Glacier & Ice Sheet Dynamics at Georgia Tech](https://github.com/nsidc/NSIDC-Data-Tutorials) - Alex Robel's slides, notes, and code demonstrations for grad/undergrad course in glaciology 
 - [GRANTSISM](http://homepages.ulb.ac.be/~fpattyn/grantism/)  - GReenland & ANTarctic Ice Sheet Model + Svalbard extension, based on Excel with suggested exercises  ([p](https://doi.org/10.1016/j.cageo.2005.06.020) [p](https://doi.org/10.1080/10899995.2018.1412177))
 - [js-ism](https://github.com/mewo2/js-ism) - Reimplementation of GRANTISM in Javascript
 - [icepack-examples](https://github.com/danshapero/icepack-examples) - Example code for the glacier modelling library icepack
+- [International Summer School in Glaciology, McCarthy, Alaska](https://glaciers.gi.alaska.edu/courses/summerschool) - bi-annual summer school hosted by University of Alaska in Fairbanks
+  - [McCarthy course material](https://glaciers.gi.alaska.edu/content/course-material-0) - Lecture notes on Ice Sheet Modelling, Mass Balance, Glacier Hydrology, Remote Sensing, and so on.
+  - [Ed Bueler's material](https://github.com/bueler/mccarthy) - Slides, notes, and codes on numerical glacier and ice sheet modeling
+  - [Andy Aschwanden's material](https://github.com/aaschwanden/mccarthy-summerschool) - Lecture notes and exercises on ice flow and thermodynamics
 - [Lindsey Nicholson's teaching](https://github.com/linznicholson/teaching) - Materials Lindsey developed for teaching (mainly) about glaciers
 - [Physics of Glacier lecture at ETH](http://people.ee.ethz.ch/~luethim/teaching.html) - All the course material for the "Physics of Glaciers" class
 - [Subglacial processes workshop material](https://maurow.bitbucket.io/teaching/copenhagen2014.html) - Mauro Werder's material from the subglacial processes workshop Copenhagen


### PR DESCRIPTION
Link to a comprehensive set of glaciology material from the [International Summer School in Glaciology held at McCarthy, Alaska](https://glaciers.gi.alaska.edu/courses/summerschool) that is organized by University of Alaska in Fairbanks. Also placed Ed Bueler and Andy Aschwanden's McCarthy material on Github as a nested list entry under this bullet point.

Question: Should the 'GIS Educational Tools and Data' section be renamed to something like 'Educational Materials' and moved up into a dedicated section? Just that the items under here doesn't appear to be 'GIS' only.