### PR TITLE
Add xDEM repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A prototype of a curated list of awesome data sources, models, tools and organiz
 
 ## Cryosphere - across all subspheres
 ### Cryo Software
+- [xDEM](https://github.com/GlacioHack/xdem) - A Python module developed by glaciologists for handling DEMs: read/write, coregistration, volume change calculation etc.
 ### Cryo Data 
 - [NSIDC](https://nsidc.org/) - The (US) National Snow and Ice Data Center
 - [NSIDC Data Tutorials](https://github.com/nsidc/NSIDC-Data-Tutorials) - Jupyter notebook guides to access, subset, transform, and visualize data products from NSIDC


### PR DESCRIPTION
It feels a bit bold to put it at the very start of the list... I saw there is a section on remote sensing software, which would be appropriate, but it's under the ISG category, whereas xDEM is more generic than that.
Actually maybe some of the remote sensing software could also go at the start, as long as they are not specific to ISG.